### PR TITLE
Hide Checklist if it doesn't exist on a page

### DIFF
--- a/biz_content/templates/biz_content/step_page.html
+++ b/biz_content/templates/biz_content/step_page.html
@@ -57,15 +57,17 @@
         </div><!-- /.blog-main -->
 
         <div class="col-sm-3 col-sm-offset-1 blog-sidebar">
+          {% if self.checklist.items %}
           <div class="sidebar-module sidebar-module-inset">
             <h4>Checklist</h4>
             <hr>
             {% for item in self.checklist.items %}
-            <div class="checkbox">
-  				<label><input type="checkbox" value="">{{item}}</label>
-			</div>
-			     {% endfor %}
+              <div class="checkbox">
+                <label><input type="checkbox" value="">{{item}}</label>
+              </div>
+            {% endfor %}
           </div>
+          {% endif %}
           <br><br>
           <!-- <div class="sidebar-module">
             <h4>Resources</h4>

--- a/biz_content/templates/biz_content/step_page.html
+++ b/biz_content/templates/biz_content/step_page.html
@@ -26,7 +26,7 @@
 
       <div class="row">
 
-        <div style="border-right:1px solid #333;" class="col-sm-8 blog-main">
+        <div class="col-sm-9 blog-main">
         {% for p in page.content_paragraph.all %}
           <div class="blog-post">
             <h2 class="blog-post-title">{{p.header}}</h2>
@@ -56,29 +56,29 @@
 
         </div><!-- /.blog-main -->
 
-        <div class="col-sm-3 col-sm-offset-1 blog-sidebar">
-          {% if self.checklist.items %}
-          <div class="sidebar-module sidebar-module-inset">
-            <h4>Checklist</h4>
-            <hr>
-            {% for item in self.checklist.items %}
-              <div class="checkbox">
-                <label><input type="checkbox" value="">{{item}}</label>
+        {% if self.checklist.items %}
+          <div style="border-left:1px solid #333;" class="col-sm-3 blog-sidebar">
+              <div class="sidebar-module sidebar-module-inset">
+                <h4>Checklist</h4>
+                <hr>
+                {% for item in self.checklist.items %}
+                  <div class="checkbox">
+                    <label><input type="checkbox" value="">{{item}}</label>
+                  </div>
+                {% endfor %}
               </div>
-            {% endfor %}
-          </div>
-          {% endif %}
-          <br><br>
-          <!-- <div class="sidebar-module">
-            <h4>Resources</h4>
-            <hr>
-            <ol class="list-unstyled">
-              <li><a href="#">GitHub</a></li>
-              <li><a href="#">Twitter</a></li>
-              <li><a href="#">Facebook</a></li>
-            </ol>
-          </div> -->
-        </div><!-- /.blog-sidebar -->
+            <br><br>
+            <!-- <div class="sidebar-module">
+              <h4>Resources</h4>
+              <hr>
+              <ol class="list-unstyled">
+                <li><a href="#">GitHub</a></li>
+                <li><a href="#">Twitter</a></li>
+                <li><a href="#">Facebook</a></li>
+              </ol>
+            </div> -->
+          </div><!-- /.blog-sidebar -->
+        {% endif %}
 
       </div><!-- /.row -->
 


### PR DESCRIPTION
Closes #9. Simple thing, just hides the checklist heading if there's no checklist:

<img width="1279" alt="screen shot 2016-11-29 at 2 08 52 pm" src="https://cloud.githubusercontent.com/assets/1418949/20731058/7247787e-b63d-11e6-981f-0adc0653583d.png">

@racheledelman might want to think about the layout of the page if there's a better way to do this layout.
