### PR TITLE
Add src folder to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 *.ipynb
 .ipynb_checkpoints/
 /list/
+src/


### PR DESCRIPTION
The wealthmap src folder keeps getting created in my local environment and not deleting. Not sure why this is happening @glassresistor, but I'm adding this folder to gitignore so it doesn't end up in source code. 