### PR TITLE
Move wagtail admin button

### DIFF
--- a/syracuse_bizport/static/css/syracuse_bizport.css
+++ b/syracuse_bizport/static/css/syracuse_bizport.css
@@ -40,6 +40,17 @@ header.step{
 	margin-bottom: 100px;
 }
 
+/* Reposition wagtail admin button away from chat */
+.wagtail-userbar-trigger {
+	bottom: 35px;
+	left: 10px;
+}
+
+.wagtail-userbar-items {
+	bottom: 90px;
+	right: -10px;
+}
+
 /*!
  * Start Bootstrap - Freelancer v3.3.7+1 (http://startbootstrap.com/template-overviews/freelancer)
  * Copyright 2013-2016 Start Bootstrap


### PR DESCRIPTION
Quick css fix: make it so the wagtail admin button isn't covered by the chat.

<img width="408" alt="screen shot 2016-12-07 at 2 46 30 pm" src="https://cloud.githubusercontent.com/assets/1418949/20990082/0c772242-bc8c-11e6-9fb5-8efdb08d2a5b.png">
