### PR TITLE
Check if link has been set before running template tag

### DIFF
--- a/syracuse_bizport/templates/footer.html
+++ b/syracuse_bizport/templates/footer.html
@@ -8,9 +8,15 @@
             <div class="container">
                 <div class="row">
                     <div class="col-sm-4">
-                      <a href="{% pageurl settings.biz_content.FooterSettings.first_link %}"><p>{{ settings.biz_content.FooterSettings.first_link }}</p></a>
-                      <a href="{% pageurl settings.biz_content.FooterSettings.second_link %}"><p>{{ settings.biz_content.FooterSettings.second_link }}</p></a>
-                      <a href="{% pageurl settings.biz_content.FooterSettings.third_link %}"><p>{{ settings.biz_content.FooterSettings.third_link }}</p></a>
+                      {% if settings.biz_content.FooterSettings.first_link %}
+                        <a href="{% pageurl settings.biz_content.FooterSettings.first_link %}"><p>{{ settings.biz_content.FooterSettings.first_link }}</p></a>
+                      {% endif %}
+                      {% if settings.biz_content.FooterSettings.second_link %}
+                        <a href="{% pageurl settings.biz_content.FooterSettings.second_link %}"><p>{{ settings.biz_content.FooterSettings.second_link }}</p></a>
+                      {% endif %}
+                      {% if settings.biz_content.FooterSettings.third_link %}
+                        <a href="{% pageurl settings.biz_content.FooterSettings.third_link %}"><p>{{ settings.biz_content.FooterSettings.third_link }}</p></a>
+                      {% endif %}
                     </div>
                     <div class="col-sm-4">
                       <p><strong>{{ settings.biz_content.FooterSettings.department_name }}</strong></p>


### PR DESCRIPTION
Just wanted to do a quick write-up of what happened:

I forgot to test whether or not 3 pages had been selected in the footer settings before rendering the footer. This wouldn't normally cause an issue, except that in this case we were using the wagtail pageurl tag: https://github.com/codeforamerica/syracuse_biz_portal/pull/160/commits/268cf8b04943ce851beb662f66c44793b65541b6#diff-d7f9652623e187977012303e517c3594L12

This managed to get through both the review app and staging because I logged in to add the settings to test that they appeared before loading the site without them. However, when it was deployed to master without the settings set we got a template error.