### PR TITLE
collection and step page headers match, swapped colors

### DIFF
--- a/biz_content/templates/biz_content/step_page.html
+++ b/biz_content/templates/biz_content/step_page.html
@@ -9,42 +9,48 @@
 <!--
  -->
  <!-- Navigation -->
-
-    <header>
-      {% image self.header_img width-1200 as header_img %}
-      <div class="hero-background" style="background-image: url({{ header_img.url }})">
-        <div class="jumbotron hero-shade">
-          <div class="blog-header container">
-            <div class="row">
-              <div class="col-sm-9">
-                {% if self.get_ancestors|length > 1 %}
-                  <ol class="breadcrumb">
-
-                  {% for page in self.get_ancestors %}
-                    {% if page.is_root == False %}
-                      <li><a href="{% pageurl page %}">{{ page.title }}</a></li>
-                    {% endif %}
-                  {% endfor %}
-
-                  <li class="active">{{ self.title }}</li>
-
-                  </ol>
-                {% endif %}
-                <h1 class="blog-title">{{ page.title }}</h1>
-                {% if page.description %}
-                  <h2 class="lead blog-description">{{page.description}}</h2>
-                {% endif %}
-              </div>
-            </div>
+<header>
+  {% image self.header_img width-1200 as header_img %}
+  <div class="hero-background" style="background-image: url({{ header_img.url }})">
+    <div class="shade-bar">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-6">
+            {% if self.get_ancestors|length > 1 %}
+            <ol class="breadcrumb">
+            {% for page in self.get_ancestors %}
+              {% if page.is_root == False %}
+                <li><a href="{% pageurl page %}">{{ page.title }}</a></li>
+              {% endif %}
+            {% endfor %}
+            <li class="active">{{ self.title }}</li>
+            </ol>
           </div>
         </div>
       </div>
-    </header>
-
+    </div>
+    <div class="jumbotron collection-shade">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-9">
+            {% endif %}
+            <h1 class="blog-title">
+              {% if page.icon %}
+                {% image page.icon width-120 %}
+              {% endif %}
+              {{ page.title }}
+            </h1>
+            {% if page.description %}
+              <h2 class="lead blog-description">{{page.description}}</h2>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
     <div class="container">
-
       <div class="row">
-
         <div class="col-sm-7  blog-main">
           <article>
             {% for block in page.page_content %}

--- a/syracuse_bizport/static/css/syracuse_bizport.css
+++ b/syracuse_bizport/static/css/syracuse_bizport.css
@@ -56,7 +56,11 @@ header.step{
 }
 
 .collection-shade {
-  background: #5C802C;
+  background: #3F47A1; /* Old browsers */
+  background: -moz-linear-gradient(-45deg, rgba(63, 71, 161, 0.8) 0%, rgba(60, 44, 91, 0.7) 100%); /* FF3.6-15 */
+  background: -webkit-linear-gradient(-45deg, rgba(63, 71, 161, 0.8) 0%,rgba(60, 44, 91, 0.7) 100%); /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(135deg, rgba(63, 71, 161, 0.8) 0%,rgba(60, 44, 91, 0.7) 100%) /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='rgba(63, 71, 161, 0.8)', endColorstr='rgba(60, 44, 91, 0.7)',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
 }
 .collection-shade h1 img {
   height: 55px;
@@ -69,11 +73,7 @@ header.step{
 }
 }
 .shade-bar {
-  background: #3F47A1; /* Old browsers */
-  background: -moz-linear-gradient(-45deg, rgba(63, 71, 161, 0.8) 0%, rgba(60, 44, 91, 0.7) 100%); /* FF3.6-15 */
-  background: -webkit-linear-gradient(-45deg, rgba(63, 71, 161, 0.8) 0%,rgba(60, 44, 91, 0.7) 100%); /* Chrome10-25,Safari5.1-6 */
-  background: linear-gradient(135deg, rgba(63, 71, 161, 0.8) 0%,rgba(60, 44, 91, 0.7) 100%) /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='rgba(63, 71, 161, 0.8)', endColorstr='rgba(60, 44, 91, 0.7)',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
+  background: #5C802C;
 }
 .jumbotron h1 {
 	margin-top: 0;
@@ -81,7 +81,7 @@ header.step{
 .jumbotron h2 {
 	margin-bottom: 0;
   margin-top: 0;
-  color: #000;
+  color: #fff;
 }
 
 .hero-background {

--- a/syracuse_bizport/static/css/syracuse_bizport.css
+++ b/syracuse_bizport/static/css/syracuse_bizport.css
@@ -81,7 +81,10 @@ header.step{
 .jumbotron h2 {
 	margin-bottom: 0;
   margin-top: 0;
-  color: #fff;
+  color: #000;
+}
+.tracker-promo .jumbotron h2 {
+	color: #fff;
 }
 
 .hero-background {


### PR DESCRIPTION
@cweems re: your feedback about inconsistency between page headers, how do you like this? All headers are now purple, all interior page breadcrumbs are green.

![image](https://cloud.githubusercontent.com/assets/2693690/22611882/03fcdcf6-ea22-11e6-9ce1-cf65d03a7c02.png)

![image](https://cloud.githubusercontent.com/assets/2693690/22611887/0a6ad304-ea22-11e6-9a7d-a4054c7be2b6.png)
